### PR TITLE
Update to Cake 2.2

### DIFF
--- a/src/Cake.Ftp.Tests/Cake.Ftp.Tests.csproj
+++ b/src/Cake.Ftp.Tests/Cake.Ftp.Tests.csproj
@@ -1,18 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="0.37.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Cake.Testing" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Cake.Ftp.Tests/FtpTests.cs
+++ b/src/Cake.Ftp.Tests/FtpTests.cs
@@ -16,7 +16,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                 .ParamName.Should().Equals("fileSystem");
+                 .ParamName.Should().BeEquivalentTo("fileSystem");
             }
 
             [Fact]
@@ -29,7 +29,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                .ParamName.Should().Equals("environment");
+                .ParamName.Should().BeEquivalentTo("environment");
             }
 
             [Fact]
@@ -42,7 +42,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                .ParamName.Should().Equals("ftpService");
+                .ParamName.Should().BeEquivalentTo("ftpService");
             }
         }
 
@@ -57,7 +57,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("host");
+                   .ParamName.Should().BeEquivalentTo("host");
             }
 
             [Fact]
@@ -71,7 +71,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                    .ParamName.Should().Equals("remotePath");
+                    .ParamName.Should().BeEquivalentTo("remotePath");
             }
 
             [Fact]
@@ -84,7 +84,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                  .ParamName.Should().Equals("fileToUpload");
+                  .ParamName.Should().BeEquivalentTo("fileToUpload");
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("Username");
+                   .ParamName.Should().BeEquivalentTo("Username");
             }
 
             [Fact]
@@ -110,7 +110,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("Password");
+                   .ParamName.Should().BeEquivalentTo("Password");
             }
 
             [Fact]
@@ -139,7 +139,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                    .ParamName.Should().Equals("host");
+                    .ParamName.Should().BeEquivalentTo("host");
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                    .ParamName.Should().Equals("remotePath");
+                    .ParamName.Should().BeEquivalentTo("remotePath");
             }
 
             [Fact]
@@ -166,7 +166,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                  .ParamName.Should().Equals("Username");
+                  .ParamName.Should().BeEquivalentTo("Username");
             }
 
             [Fact]
@@ -179,7 +179,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                 .ParamName.Should().Equals("Password");
+                 .ParamName.Should().BeEquivalentTo("Password");
             }
 
             [Fact]
@@ -209,7 +209,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("host");
+                   .ParamName.Should().BeEquivalentTo("host");
             }
 
             [Fact]
@@ -223,7 +223,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                    .ParamName.Should().Equals("remotePath");
+                    .ParamName.Should().BeEquivalentTo("remotePath");
             }
 
             [Fact]
@@ -237,7 +237,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                  .ParamName.Should().Equals("sourceDirectory");
+                  .ParamName.Should().BeEquivalentTo("sourceDirectory");
             }
 
             [Fact]
@@ -251,7 +251,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("Username");
+                   .ParamName.Should().BeEquivalentTo("Username");
             }
 
             [Fact]
@@ -265,7 +265,7 @@ namespace Cake.Ftp.Tests {
 
                 // Then
                 result.Should().BeOfType<ArgumentNullException>().Subject
-                   .ParamName.Should().Equals("Password");
+                   .ParamName.Should().BeEquivalentTo("Password");
             }
 
             [Fact]

--- a/src/Cake.Ftp/Cake.Ftp.csproj
+++ b/src/Cake.Ftp/Cake.Ftp.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.37.0" PrivateAssets="All" />
-    <PackageReference Include="FluentFTP" Version="32.2.1" />
+    <PackageReference Include="Cake.Core" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="FluentFTP" Version="39.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.Ftp/FtpClient.cs
+++ b/src/Cake.Ftp/FtpClient.cs
@@ -139,7 +139,7 @@ namespace Cake.Ftp {
         private void CheckParams(string host, string remotePath, FtpSettings settings)
         {
             host.NotNullOrWhiteSpace(nameof(host));
-            remotePath.NotNullOrWhiteSpace(nameof(host));
+            remotePath.NotNullOrWhiteSpace(nameof(remotePath));
             settings.Username.NotNullOrWhiteSpace(nameof(settings.Username));
             settings.Password.NotNullOrWhiteSpace(nameof(settings.Password));
         }

--- a/src/Cake.Ftp/Services/FtpService.cs
+++ b/src/Cake.Ftp/Services/FtpService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using FluentFTP;
+using FluentFTP.Helpers;
 using FluentFTP.Rules;
 
 namespace Cake.Ftp.Services {
@@ -166,9 +167,9 @@ namespace Cake.Ftp.Services {
         private FtpRemoteExists Translate(FtpExists ftpExists) {
             switch (ftpExists) {
                 case FtpExists.Append:
-                    return FtpRemoteExists.Append;
+                    return FtpRemoteExists.Resume;
                 case FtpExists.AppendNoCheck:
-                    return FtpRemoteExists.AppendNoCheck;
+                    return FtpRemoteExists.ResumeNoCheck;
                 case FtpExists.NoCheck :
                     return FtpRemoteExists.NoCheck;
                 case FtpExists.Overwrite:


### PR DESCRIPTION
This PR contains an update to Cake 2.2 and .NET 6 along with version bumps on all of the dependencies.

There was also a typo in the CheckParams method that was preventing the tests from running successfully.